### PR TITLE
Add wrapped class name for sidekiq web interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 4.1.0'
 gem 'resque', require: false
 gem 'resque-scheduler', require: false
 gem 'sidekiq', require: false
-gem 'sucker_punch', require: false
+gem 'sucker_punch', "< 2.0", require: false
 gem 'delayed_job', require: false
 gem 'queue_classic', "< 3.0.0", require: false, platforms: :ruby
 gem 'sneakers', '0.1.1.pre', require: false

--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -8,6 +8,7 @@ module ActiveJob
           #Sidekiq::Client does not support symbols as keys
           Sidekiq::Client.push \
             'class' => JobWrapper,
+            'wrapped' => job.class.to_s,
             'queue' => job.queue_name,
             'args'  => [ job.serialize ],
             'retry' => true
@@ -16,6 +17,7 @@ module ActiveJob
         def enqueue_at(job, timestamp)
           Sidekiq::Client.push \
             'class' => JobWrapper,
+            'wrapped' => job.class.to_s,
             'queue' => job.queue_name,
             'args'  => [ job.serialize ],
             'retry' => true,

--- a/test/gemfiles/Gemfile.activesupport-4.0.x
+++ b/test/gemfiles/Gemfile.activesupport-4.0.x
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 4.0.0'
 gem 'resque', require: false
 gem 'resque-scheduler', require: false
 gem 'sidekiq', require: false
-gem 'sucker_punch', require: false
+gem 'sucker_punch', "< 2.0", require: false
 gem 'delayed_job', require: false
 gem 'queue_classic', "< 3.0.0", require: false, platforms: :ruby
 gem 'sneakers', '0.1.1.pre', require: false


### PR DESCRIPTION
`Sidekiq::Web` unwraps jobs to show readable class name and parameters when `wrapped` field is present.
Also original activejob has it.
